### PR TITLE
feat: add skeleton loader for NFT cards in dashboard

### DIFF
--- a/econft-frontend/src/app/(user)/dashboard/page.tsx
+++ b/econft-frontend/src/app/(user)/dashboard/page.tsx
@@ -9,34 +9,45 @@ import { useEffect, useState } from "react";
 export default function Dashboard() {
   const { username, authToken } = useUser();
   const [trees, setTrees] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const getTrees = async () => {
-      const res = await fetch(`${BASE_URL}/nft/my-nfts`, {
-        headers: {
-          "Authorization": `Bearer ${authToken}`
-        }
-      });
-      const data = await res.json();
-      if (data.success) {
-        const { nfts } = data;
-        const arrayOfNfts = [];
-        for (const nft of nfts) {
+      try {
+        const res = await fetch(`${BASE_URL}/nft/my-nfts`, {
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+          },
+        });
+
+        const data = await res.json();
+
+        if (data.success) {
+          const { nfts } = data;
+          const arrayOfNfts = [];
+
+          for (const nft of nfts) {
             const nftObject = {
               name: nft[0],
               scientificName: nft[1],
               imageUrl: nft[2],
               uuid: nft[3],
               latitude: parseFloat(nft[4]) / 1e6,
-              longitude: parseFloat(nft[5]) / 1e6
-            }
+              longitude: parseFloat(nft[5]) / 1e6,
+            };
 
             arrayOfNfts.push(nftObject);
-        }
+          }
 
-        setTrees(arrayOfNfts);
+          setTrees(arrayOfNfts);
+        }
+      } catch (error) {
+        console.error(error);
+      } finally {
+        setLoading(false);
       }
     };
+
     getTrees();
   }, [authToken]);
 
@@ -48,7 +59,9 @@ export default function Dashboard() {
             {/*user goes here*/}
             Welcome back, {username}!
           </h1>{" "}
-          <p className="text-gray-600 dark:text-gray-400">Here&apos;s your tree planting journey</p>
+          <p className="text-gray-600 dark:text-gray-400">
+            Here&apos;s your tree planting journey
+          </p>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8 mx-4">
@@ -58,8 +71,12 @@ export default function Dashboard() {
                 <Trees className="w-6 h-6 text-green-600 dark:text-green-400" />
               </div>
               <div>
-                <div className="text-2xl font-bold text-gray-900 dark:text-white">{trees.length}</div>
-                <div className="text-sm text-gray-600 dark:text-gray-400">Trees Planted</div>
+                <div className="text-2xl font-bold text-gray-900 dark:text-white">
+                  {trees.length}
+                </div>
+                <div className="text-sm text-gray-600 dark:text-gray-400">
+                  Trees Planted
+                </div>
               </div>
             </div>
           </div>
@@ -69,8 +86,12 @@ export default function Dashboard() {
                 <Award className="w-6 h-6 text-green-600 dark:text-green-400" />
               </div>
               <div>
-                <div className="text-2xl font-bold text-gray-900 dark:text-white">#1</div>
-                <div className="text-sm text-gray-600 dark:text-gray-400">Leaderboard Rank</div>
+                <div className="text-2xl font-bold text-gray-900 dark:text-white">
+                  #1
+                </div>
+                <div className="text-sm text-gray-600 dark:text-gray-400">
+                  Leaderboard Rank
+                </div>
               </div>
             </div>
           </div>
@@ -86,20 +107,38 @@ export default function Dashboard() {
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mx-4">
-          {trees.map((tree) => (
-            <div key={tree.uuid} className="card bg-white dark:bg-green-900/30 dark:border dark:border-green-800/50 rounded-xl p-4">
-              <img
-                src={tree.imageUrl}
-                alt={tree.name}
-                className="w-full h-48 object-cover rounded-lg mb-4"
-              />
-              <h3 className="font-semibold text-green-500">{tree.name}</h3>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">{tree.latitude}, {tree.longitude}</p>
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-gray-500 dark:text-gray-400">{tree.date}</span>
-              </div>
-            </div>
-          ))}
+          {loading
+            ? Array.from({ length: 6 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="animate-pulse card bg-white dark:bg-green-900/30 rounded-xl p-4"
+                >
+                  <div className="w-full h-48 bg-gray-300 dark:bg-gray-700 rounded-lg mb-4"></div>
+                  <div className="h-4 bg-gray-300 dark:bg-gray-700 rounded w-3/4 mb-2"></div>
+                  <div className="h-3 bg-gray-300 dark:bg-gray-700 rounded w-1/2"></div>
+                </div>
+              ))
+            : trees.map((tree) => (
+                <div
+                  key={tree.uuid}
+                  className="card bg-white dark:bg-green-900/30 dark:border dark:border-green-800/50 rounded-xl p-4"
+                >
+                  <img
+                    src={tree.imageUrl}
+                    alt={tree.name}
+                    className="w-full h-48 object-cover rounded-lg mb-4"
+                  />
+                  <h3 className="font-semibold text-green-500">{tree.name}</h3>
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">
+                    {tree.latitude}, {tree.longitude}
+                  </p>
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-gray-500 dark:text-gray-400">
+                      {tree.date}
+                    </span>
+                  </div>
+                </div>
+              ))}
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Added Skeleton Loader for NFT Cards

Implemented skeleton loaders for NFT cards on the dashboard while NFT data is being fetched from the API.

- Added loading state
- Display skeleton card placeholders during data fetch
- Render actual NFT cards once data is loaded

This improves the user experience by avoiding empty UI while the data is loading.

Fixes #36 